### PR TITLE
docs: fix environment variable name for Gemini API

### DIFF
--- a/genkit-angular-starter-kit/README.md
+++ b/genkit-angular-starter-kit/README.md
@@ -20,7 +20,7 @@ This example will use the Gemini API which provides a generous free tier and doe
 To use the Gemini API, you'll need an API key. If you don't already have one, create a key in Google AI Studio.
 
 1. [Get an API key from Google AI Studio](https://makersuite.google.com/app/apikey)
-1. After you’ve created an API key, set the `GEMINI_API_KEY` environment variable to your key with the command `export GEMINI_API_KEY=<your API key>`
+1. After you’ve created an API key, set the `GEMINI_API_KEY` environment variable to your key with the command `export GOOGLE_GENAI_API_KEY=<your API key>`
 1. Clone this repository or download the code to your local machine
 1. `cd` into the root folder (e.g., `cd genkit-angular-starter-kit`)
 1. Install the dependencies with `npm install`


### PR DESCRIPTION
I followed the guide on genkit-angular-starter-kit/README.md but `GEMINI_API_KEY` env var doesn't work. As the error says, the correct var name is now `GOOGLE_GENAI_API_KEY`. 

```
Non-streaming request failed with error: Please pass in the API key or set the GOOGLE_GENAI_API_KEY or GOOGLE_API_KEY environment variable.
For more details see https://firebase.google.com/docs/genkit/plugins/google-genai
Error: Please pass in the API key or set the GOOGLE_GENAI_API_KEY or GOOGLE_API_KEY environment variable.
For more details see https://firebase.google.com/docs/genkit/plugins/google-genai
    at defineGoogleAIModel2 (/Users/lacolaco/works/angular/examples/genkit-angular-starter-kit/.angular/cache/19.2.5/app/vite/deps_ssr/@genkit-ai_googleai.js:2699:15)
```

I confirmed it works with `GOOGLE_GENAI_API_KEY` on my machine.